### PR TITLE
Clean up HTML tags

### DIFF
--- a/lib/dradis/plugins/qualys/gem_version.rb
+++ b/lib/dradis/plugins/qualys/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 3
         MINOR = 0
-        TINY = 1
+        TINY = 2
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/qualys/element.rb
+++ b/lib/qualys/element.rb
@@ -95,8 +95,8 @@ module Qualys
       result.gsub!(/<p>/i, "\n\n")
       result.gsub!(/<br>/i, "\n")
       result.gsub!(/          /, "")
-      result.gsub!(/<A HREF=\"(.*?)\" TARGET=\"_blank\">(.*?)<\/A>/i) { "\"#{$2.strip}\":#{$1.strip}" }
-      result.gsub!(/<PRE>(.*?)<\/PRE>/m) { |m| "\n\nbc.. #{$1.strip}\n\np.  \n" }
+      result.gsub!(/<a href=\"(.*?)\" target=\"_blank\">(.*?)<\/a>/i) { "\"#{$2.strip}\":#{$1.strip}" }
+      result.gsub!(/<pre>(.*?)<\/pre>/im) { |m| "\n\nbc.. #{$1.strip}\n\np.  \n" }
       result.gsub!(/<b>(.*?)<\/b>/i) { "*#{$1.strip}*" }
       result.gsub!(/<i>(.*?)<\/i>/i) { "_#{$1.strip}_" }
       result

--- a/lib/qualys/element.rb
+++ b/lib/qualys/element.rb
@@ -89,13 +89,16 @@ module Qualys
     end
 
     private
-      
+
     def cleanup_html(source)
       result = source.dup
-      result.gsub!(/<P>/, "\n\n")
-      result.gsub!(/<BR>/, "\n")
+      result.gsub!(/<p>/i, "\n\n")
+      result.gsub!(/<br>/i, "\n")
       result.gsub!(/          /, "")
-      result.gsub!(/<A HREF=\"(.*?)\" TARGET=\"_blank\">(.*?)<\/A>/) { "\"#{$2.strip}\":#{$1.strip}" }
+      result.gsub!(/<A HREF=\"(.*?)\" TARGET=\"_blank\">(.*?)<\/A>/i) { "\"#{$2.strip}\":#{$1.strip}" }
+      result.gsub!(/<PRE>(.*?)<\/PRE>/m) { |m| "\n\nbc.. #{$1.strip}\n\np.  \n" }
+      result.gsub!(/<b>(.*?)<\/b>/i) { "*#{$1.strip}*" }
+      result.gsub!(/<i>(.*?)<\/i>/i) { "_#{$1.strip}_" }
       result
     end
 


### PR DESCRIPTION
This tag removes the incorrectly formatted tags (e.g. `<P>` and `<A>`) from the Diagnosis and Solution sections. It also resolves https://github.com/dradis/dradis-ce/issues/84