### PR TITLE
Import INFOS, SERVICES, etc as Issues 

### DIFF
--- a/lib/dradis/plugins/qualys/gem_version.rb
+++ b/lib/dradis/plugins/qualys/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 3
         MINOR = 6
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/dradis/plugins/qualys/gem_version.rb
+++ b/lib/dradis/plugins/qualys/gem_version.rb
@@ -8,8 +8,8 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 6
-        TINY = 1
+        MINOR = 7
+        TINY = 0
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/dradis/plugins/qualys/importer.rb
+++ b/lib/dradis/plugins/qualys/importer.rb
@@ -41,36 +41,11 @@ module Dradis::Plugins::Qualys
       end
       content_service.create_note text: host_text, node: self.host_node
 
-      # We'll deal with 'VULNS' separately
-      ['INFOS', 'SERVICES', 'PRACTICES'].each do |collection|
+      # We treat INFOS, SERVICES, PRACTICES, and VULNS the same way
+      # All of these are imported into Dradis as Issues
+      ['INFOS', 'SERVICES', 'PRACTICES', 'VULNS'].each do |collection|
         xml_host.xpath(collection).each do |xml_collection|
           process_collection(collection, xml_collection)
-        end
-      end
-
-      # Now we focus on 'VULNS' which we convert into Issue/Evidence
-      #
-      # For each <VULN> we need a reference to the parent <CAT> object for
-      # information such as port or protocol.
-      #
-      # Before we hand this to the template_service we need to make sure that
-      # a single VULN is hanging from the parent. To avoid messing the
-      # original document structure we just dup it.
-      logger.info{ "Extracting VULNS" }
-
-      xml_host.xpath('VULNS/CAT').each do |xml_cat|
-
-        empty_dup_xml_cat = xml_cat.dup
-        empty_dup_xml_cat.children.remove
-
-        xml_cat.xpath('VULN').each do |xml_vuln|
-          vuln_number = xml_vuln[:number]
-
-          # We need to clear any siblings before or after this VULN
-          dup_xml_cat = empty_dup_xml_cat.dup
-          dup_xml_cat.add_child(xml_vuln.dup)
-
-          process_vuln(vuln_number, dup_xml_cat)
         end
       end
     end
@@ -82,48 +57,27 @@ module Dradis::Plugins::Qualys
       xml_cats.each do |xml_cat|
         logger.info{ "\t#{ collection } - #{ xml_cat['value'] }" }
 
-        if xml_cats.count == 1
-          category_node = content_service.create_node(
-            label: "#{ collection.downcase } - #{ xml_cats.first['value'] }",
-            type: :default,
-            parent: self.host_node)
-        else
-          collection_node ||= content_service.create_node(
-            label: collection.downcase,
-            type: :default,
-            parent: self.host_node)
-          category_node = content_service.create_node(
-            label: xml_cat['value'],
-            type: :default,
-            parent: collection_node)
-        end
-
         empty_dup_xml_cat = xml_cat.dup
         empty_dup_xml_cat.children.remove
 
-        # For each INFOS/CAT/INFO, SERVICES/CAT/SERVICE, etc.
+        # For each INFOS/CAT/INFO, SERVICES/CAT/SERVICE, VULNS/CAT/VULN, etc.
         xml_cat.xpath(collection.chop).each do |xml_element|
           dup_xml_cat = empty_dup_xml_cat.dup
           dup_xml_cat.add_child(xml_element.dup)
+          cat_number = xml_element[:number]
 
-          note_content = template_service.process_template(template: 'element', data: dup_xml_cat)
+          process_vuln(collection, cat_number, dup_xml_cat)
 
-          # retrieve hosts affected by this issue
-          note_content << "\n#[host]#\n"
-          note_content << self.host_node.label
-          note_content << "\n\n"
-
-          content_service.create_note text: note_content, node: category_node
         end
       end
     end
 
     # Takes a <CAT> element containing a single <VULN> element and processes an
     # Issue and Evidence template out of it.
-    def process_vuln(vuln_number, xml_cat)
+    def process_vuln(collection, vuln_number, xml_cat)
       logger.info{ "\t\t => Creating new issue (plugin_id: #{ vuln_number })" }
       issue_text = template_service.process_template(template: 'element', data: xml_cat)
-      issue_text << "\n\n#[Number]#\n#{ vuln_number }\n\n"
+      issue_text << "\n\n#[qualys_collection]#\n#{ collection }"
       issue = content_service.create_issue(text: issue_text, id: vuln_number)
 
       logger.info{ "\t\t => Creating new evidence" }

--- a/lib/dradis/plugins/qualys/importer.rb
+++ b/lib/dradis/plugins/qualys/importer.rb
@@ -51,7 +51,6 @@ module Dradis::Plugins::Qualys
     end
 
     def process_collection(collection, xml_collection)
-      collection_node = nil
       xml_cats = xml_collection.xpath('CAT')
 
       xml_cats.each do |xml_cat|

--- a/spec/qualys/importer_spec.rb
+++ b/spec/qualys/importer_spec.rb
@@ -4,7 +4,7 @@ require "ostruct"
 describe Dradis::Plugins::Qualys::Importer do
   let(:plugin) { Dradis::Plugins::Qualys }
 
-  let(:content_service)  { Dradis::Plugins::ContentService.new(plugin: plugin) }
+  let(:content_service)  { Dradis::Plugins::ContentService::Base.new(plugin: plugin) }
   let(:template_service) { Dradis::Plugins::TemplateService.new(plugin: plugin) }
 
   let(:importer) {
@@ -33,8 +33,6 @@ describe Dradis::Plugins::Qualys::Importer do
 
   let(:example_xml) { 'spec/fixtures/files/simple.xml' }
 
-  pending "collapses INFOS|SERVICES|VULNS|PRACTICES node if only a single element is found"
-
   def run_import!
     importer.import(file: example_xml)
   end
@@ -42,14 +40,6 @@ describe Dradis::Plugins::Qualys::Importer do
   it "creates nodes as needed" do
     # Host node
     expect_to_create_node_with(label: '10.0.155.160')
-
-    # Information gathering node
-    expect_to_create_node_with(label: 'infos - Information gathering')
-
-    # Services node with its child nodes
-    expect_to_create_node_with(label: 'services')
-    expect_to_create_node_with(label: 'TCP/IP')
-    expect_to_create_node_with(label: 'Web server')
 
     run_import!
   end
@@ -59,68 +49,88 @@ describe Dradis::Plugins::Qualys::Importer do
     # Host node notes
     expect_to_create_note_with(text: "Basic host info")
 
-    # Information gathering node and notes
-    expect_to_create_note_with(
-      text: "DNS Host Name",
-      node_label: "infos - Information gathering"
-    )
-    expect_to_create_note_with(
-      text: "Host Scan Time",
-      node_label: "infos - Information gathering"
-    )
-
-    # Child notes of Services node
-    expect_to_create_note_with(
-      text: "Open TCP Services List",
-      node_label: "TCP/IP"
-    )
-
-    expect_to_create_note_with(
-      text: "Web Server Version",
-      node_label: "Web server"
-    )
-
     run_import!
   end
 
   # Issues and evidences from vulns
-  # There are 3 vulns in total:
+  # There are 7 vulns/infos/services in total:
+  #   - DNS Host Name
+  #   - Host Scan Time
+  #   - Open TCP Services List
+  #   - Web Server Version
   #   - TCP/IP: Sequence number in both hosts
   #   - Web server: Apache 1.3
   #   - Web server: ETag
-  # Each one should create 1 issue and 1 evidence
 
   it "creates issues from vulns" do
     expect_to_create_issue_with(
-      text: "Sequence Number Approximation Based Denial of Service"
+      text: "DNS Host Name"
+    )
+
+    expect_to_create_issue_with(
+      text: "Host Scan Time"
+    )
+
+    expect_to_create_issue_with(
+      text: "Open TCP Services List"
+    )
+
+    expect_to_create_issue_with(
+      text: "Web Server Version"
+    )
+
+    expect_to_create_issue_with(
+      text: "TCP Sequence Number Approximation Based Denial of Service"
     )
 
     expect_to_create_issue_with(
       text: "Apache 1.3 HTTP Server Expect Header Cross-Site Scripting"
     )
-
+    
     expect_to_create_issue_with(
       text: "Apache Web Server ETag Header Information Disclosure Weakness"
     )
-
+    
     run_import!
   end
 
   it "creates evidence from vulns" do
     expect_to_create_evidence_with(
-      content: "Tested on port 80 with an injected SYN/RST offset by 16 bytes.",
-      issue: "Sequence Number Approximation Based Denial of Service",
+      content: "IP address\tHost name\n10.0.155.160\tNo registered hostname\n",
+      issue: "DNS Host Name",
       node_label: "10.0.155.160"
     )
 
     expect_to_create_evidence_with(
-      content: "The expectation given in the Expect request-header",
+      content: "Scan duration: 5445 seconds\n\nStart time: Fri, Dec 20 2011, 17:38:59 GMT\n\nEnd time: Fri, Dec 20 2011, 19:09:44 GMT",
+      issue: "Host Scan Time",
+      node_label: "10.0.155.160"
+    )
+
+    expect_to_create_evidence_with(
+      content: "\tDescription\tService Detected\tOS On Redirected Port\n80\twww\tWorld Wide Web HTTP\thttp",
+      issue: "Open TCP Services List",
+      node_label: "10.0.155.160"
+    )
+
+    expect_to_create_evidence_with(
+      content: "Server Version\tServer Banner\nApache 1.3\tApache",
+      issue: "Web Server Version",
+      node_label: "10.0.155.160"
+    )
+
+    expect_to_create_evidence_with(
+      content: "Tested on port 80 with an injected SYN/RST offset by 16 bytes.",
+      issue: "TCP Sequence Number Approximation Based Denial of Service",
+      node_label: "10.0.155.160"
+    )
+    expect_to_create_evidence_with(
+      content: "HTTP/1.1 417 Expectation Failed\nDate: Fri, 20 Dec 2011 19:05:57 GMT",
       issue: "Apache 1.3 HTTP Server Expect Header Cross-Site Scripting",
       node_label: "10.0.155.160"
     )
-
     expect_to_create_evidence_with(
-      content: "bee-4f12-00794aef",
+      content: "3bee-4f12-00794aef",
       issue: "Apache Web Server ETag Header Information Disclosure Weakness",
       node_label: "10.0.155.160"
     )


### PR DESCRIPTION
Previously, Qualys `INFOS`, `SERVICES`, and `PRACTICES` were being imported as Notes rather than Issues. This PR allows them to be imported as Issues (with their supporting Evidence) instead. 

Subnodes for infos, services, etc are no longer created.

A `#[qualys_collection]#` field is automatically created so that you can identify where the Issue came from (e.g. INFOS vs VULNS). 