### PR TITLE
Update tag parsing to remove formatting tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Dradis Framework 3.15 (XXXX, 2020) ##
+## Dradis Framework 3.16 (XXXX, 2020) ##
 
 * Update tag parsing to remove formatting tags
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.15 (XXXX, 2020) ##
+
+* Update tag parsing to remove formatting tags
+
 ## Dradis Framework 3.15 (November, 2019) ##
 
 *  No changes.

--- a/lib/dradis/plugins/qualys/gem_version.rb
+++ b/lib/dradis/plugins/qualys/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 3
         MINOR = 15
-        TINY = 1
+        TINY = 0
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/dradis/plugins/qualys/gem_version.rb
+++ b/lib/dradis/plugins/qualys/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 3
         MINOR = 15
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/qualys/element.rb
+++ b/lib/qualys/element.rb
@@ -107,7 +107,7 @@ module Qualys
 
       result.gsub!(/<dl>|<\/dl>/i, "\n")
       result.gsub!(/<dt>(.*?)<\/dt>/i) { "* #{$1.strip}" }
-      result.gsub!(/<DD>(.*?)<\/DD>/i) { "** #{$1.strip}" }
+      result.gsub!(/<dd>(.*?)<\/dd>/i) { "** #{$1.strip}" }
       result
     end
 

--- a/lib/qualys/element.rb
+++ b/lib/qualys/element.rb
@@ -99,15 +99,20 @@ module Qualys
       result.gsub!(/<p>/i, "\n\n")
       result.gsub!(/<br>/i, "\n")
       result.gsub!(/          /, "")
-      result.gsub!(/<a href=\"(.*?)\" target=\"_blank\">(.*?)<\/a>/i) { "\"#{$2.strip}\":#{$1.strip}" }
+      result.gsub!(/<a href=\"(.*?)\"\s?target=\"_blank\">(.*?)<\/a>/i) { "\"#{$2.strip}\":#{$1.strip}" }
       result.gsub!(/<pre>(.*?)<\/pre>/im) { |m| "\n\nbc.. #{$1.strip}\n\np.  \n" }
       result.gsub!(/<b>(.*?)<\/b>/i) { "*#{$1.strip}*" }
+      result.gsub!(/<b>|<\/b>/i, "")
       result.gsub!(/<i>(.*?)<\/i>/i) { "_#{$1.strip}_" }
+
+      result.gsub!(/<dl>|<\/dl>/i, "\n")
+      result.gsub!(/<dt>(.*?)<\/dt>/i) { "* #{$1.strip}" }
+      result.gsub!(/<DD>(.*?)<\/DD>/i) { "** #{$1.strip}" }
       result
     end
 
     def tags_with_html_content
-      [:diagnosis, :solution]
+      [:consequence, :diagnosis, :solution]
     end
 
   end

--- a/spec/qualys/importer_spec.rb
+++ b/spec/qualys/importer_spec.rb
@@ -86,7 +86,8 @@ module Dradis::Plugins
       )
       
       expect_to_create_issue_with(
-        text: "Apache Web Server ETag Header Information Disclosure Weakness"
+          text: "Apache Web Server ETag Header Information Disclosure Weakness",
+          text: "OpenBSD has released a \"patch\":ftp://ftp.openbsd.org/pub/OpenBSD/patches/3.2/common/008_httpd.patch that fixes this vulnerability. After installing the patch, inode numbers returned from the server are encoded using a private hash to avoid the release of sensitive information.\n\n\n\nCustomers"
       )
       
       run_import!
@@ -143,7 +144,7 @@ module Dradis::Plugins
     context "when an issue has no RESULT element" do
       #let(:example_xml) { 'spec/fixtures/files/no_result.xml' }
 
-      it "detects an issue without a RESULT element and applies (n/a)" do
+      it "detects an issue without a RESULT element and applies (n/a) and strips/replaces formatting tags" do
         # 1 node should be created:
         expect_to_create_node_with(label: '10.0.155.160')
 
@@ -151,7 +152,8 @@ module Dradis::Plugins
         #   - TCP/IP: Sequence number in both hosts
         # Each one should create 1 issue and 1 evidence
         expect_to_create_issue_with(
-          text: "Sequence Number Approximation Based Denial of Service"
+          text: "Sequence Number Approximation Based Denial of Service",
+          text: "Please first check the results section below for the port number on which this vulnerability was detected. If that port number is known to be used for port-forwarding, then it is the backend host that is really vulnerable.\n\n\n\nVarious implementations and products including Check Point, Cisco, Cray Inc, Hitachi, Internet Initiative Japan, Inc (IIJ), Juniper Networks, NEC, Polycom, and Yamaha are currently undergoing review. Contact the vendors to obtain more information about affected products and fixes. \"NISCC Advisory 236929 - Vulnerability Issues in TCP\":http://packetstormsecurity.org/0404-advisories/246929.html details the vendor patch status as of the time of the advisory, and identifies resolutions and workarounds."
         )
 
         expect_to_create_evidence_with(


### PR DESCRIPTION
### Summary
This PR removes formatting tags like `<DT>` and extends the HTML tag formatting to the `consequence` field. 

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.
