### PR TITLE
Add category field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.22 (mmm, 2021) ##
+
+*  Add category field for Infos, Services, Practices, and Vulns
+
 ## Dradis Framework 3.21 (February, 2021) ##
 
 *  No changes.

--- a/lib/dradis/plugins/qualys/importer.rb
+++ b/lib/dradis/plugins/qualys/importer.rb
@@ -67,7 +67,6 @@ module Dradis::Plugins::Qualys
           cat_number = xml_element[:number]
 
           process_vuln(collection, cat_number, dup_xml_cat)
-
         end
       end
     end

--- a/lib/qualys/element.rb
+++ b/lib/qualys/element.rb
@@ -88,6 +88,10 @@ module Qualys
       end
     end
 
+    def category
+      @xml.name&.titleize
+    end
+
     private
 
     def cleanup_html(source)
@@ -95,7 +99,7 @@ module Qualys
       result.gsub!(/&quot;/, '"')
       result.gsub!(/&lt;/, '<')
       result.gsub!(/&gt;/, '>')
-      
+
       result.gsub!(/<p>/i, "\n\n")
       result.gsub!(/<br>/i, "\n")
       result.gsub!(/          /, "")

--- a/templates/element.fields
+++ b/templates/element.fields
@@ -14,3 +14,4 @@ element.consequence
 element.solution
 element.compliance
 element.result
+element.category


### PR DESCRIPTION
### Summary

Allow for a `category` field when importing qualys reports.

### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
