### PR TITLE
Use a translation table for cvss3 fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ v4.3.0 ([month] 2022)
   - Upgraded gems:
     - [gem]
   - Bugs fixes:
+    - Fixes WAS CVSS3 mapping and not importing fields to the issue
     - [future tense verb] [bug fix]
     - Bug tracker items:
       - [item]

--- a/lib/qualys/was/qid.rb
+++ b/lib/qualys/was/qid.rb
@@ -48,19 +48,33 @@ module Qualys::WAS
         return
       end
 
-      method_name = method.to_s
+      process_field_value(method.to_s)
+    end
 
-      # Then we try simple children tags: TITLE, LAST_UPDATE, CVSS_BASE...
-      tag = @xml.at_xpath("./#{method_name.upcase}")
-      if tag && !tag.text.blank?
+    def process_field_value(method)
+      tag = @xml.at_xpath("./#{method.upcase}")
+
+      if method.starts_with?('cvss3')
+        process_cvss3_field(method)
+      elsif tag && !tag.text.blank?
         if tags_with_html_content.include?(method)
-          return Qualys::cleanup_html(tag.text)
+          Qualys.cleanup_html(tag.text)
         else
-          return tag.text
+          tag.text
         end
       else
         'n/a'
       end
+    end
+
+    def process_cvss3_field(method)
+      translations_table = {
+        cvss3_vector: 'CVSS_V3/ATTACK_VECTOR',
+        cvss3_base: 'CVSS_V3/BASE',
+        cvss3_temporal: 'CVSS_V3/TEMPORAL'
+      }
+
+      @xml.xpath("./#{translations_table[method.to_sym]}").text
     end
 
     private

--- a/spec/fixtures/files/simple_was.xml
+++ b/spec/fixtures/files/simple_was.xml
@@ -110,6 +110,13 @@
                 <DESCRIPTION>The fully qualified domain name of this host, if it was obtained from a DNS server, is displayed in the RESULT section.</DESCRIPTION>
                 <IMPACT>N/A</IMPACT>
                 <SOLUTION>N/A</SOLUTION>
+                <CVSS_BASE>4.3</CVSS_BASE>
+                <CVSS_TEMPORAL>3.9</CVSS_TEMPORAL>
+                <CVSS_V3>
+                    <BASE>6.1</BASE>
+                    <TEMPORAL>5.8</TEMPORAL>
+                    <ATTACK_VECTOR>Network</ATTACK_VECTOR>
+                </CVSS_V3>
             </QID>
         </QID_LIST>
     </GLOSSARY>


### PR DESCRIPTION
### Summary

The WAS CVSS3 fields are nested and not available on the root element. Add a translation table to map the CVSS3 fields properly.

### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
