### PR TITLE
Update thor task naming for consistency and present success message on upload complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+vX.XX.X (Month 2024)
+  - Update thor task names for consistency
+
 v4.13.0 (July 2024)
   - No changes
 

--- a/lib/dradis/plugins/qualys/asset/importer.rb
+++ b/lib/dradis/plugins/qualys/asset/importer.rb
@@ -48,6 +48,7 @@ module Dradis::Plugins::Qualys
           process_node(xml_node)
         end
 
+        logger.info { 'Qualys Asset file successfully imported' }
         true
       end
 

--- a/lib/dradis/plugins/qualys/vuln/importer.rb
+++ b/lib/dradis/plugins/qualys/vuln/importer.rb
@@ -43,6 +43,7 @@ module Dradis::Plugins::Qualys
           process_ip(xml_host)
         end
 
+        logger.info { 'Qualys Vuln file successfully imported' }
         return true
       end
 

--- a/lib/dradis/plugins/qualys/was/importer.rb
+++ b/lib/dradis/plugins/qualys/was/importer.rb
@@ -61,6 +61,7 @@ module Dradis::Plugins::Qualys
           process_evidence(xml_vulnerability)
         end
 
+        logger.info { 'Qualys WAS file successfully imported' }
         true
       end
 

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -1,10 +1,10 @@
 class QualysTasks < Thor
   include Rails.application.config.dradis.thor_helper_module
 
-  namespace "dradis:plugins:qualys"
+  namespace "dradis:plugins:qualys:upload"
 
-  desc "upload FILE", "upload Qualys XML results"
-  def upload(file_path)
+  desc "vuln FILE", "upload Qualys Vuln XML results"
+  def vuln(file_path)
     require 'config/environment'
 
     unless File.exists?(file_path)
@@ -18,8 +18,8 @@ class QualysTasks < Thor
     importer.import(file: file_path)
   end
 
-  desc "upload_was FILE", "upload Qualys WAS XML results"
-  def upload_was(file_path)
+  desc "was FILE", "upload Qualys WAS XML results"
+  def was(file_path)
     require 'config/environment'
 
     unless File.exists?(file_path)


### PR DESCRIPTION
### Summary
Currently, the thor task naming is not clear (`upload` refers to a Vuln upload but it is not specified) nor is it consistent with other upload integrations. This change updates the thor task naming for consistency and clarity

Additionally, Qualys importers do not display a success message after they have finished importing which leaves the user wondering if the upload was completed when done through the command line. This includes the addition of a success message in each importer's `import` method

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
~- [ ] Added specs~
