### PR TITLE
Add exploitability as available field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v5.XX.XX (XXXX 2026)
+  - Add `exploitability` as an available vuln field
+
 v5.0.0 (March 2025)
  - Remove HTML tags when importing WAS scans
 

--- a/lib/dradis/plugins/qualys/mapping.rb
+++ b/lib/dradis/plugins/qualys/mapping.rb
@@ -25,6 +25,7 @@ module Dradis::Plugins::Qualys
         'Description' => "{{ qualys[element.diagnosis] }}\n{{ qualys[element.consequence] }}",
         'Solution' => '{{ qualys[element.solution] }}',
         'References' => '{{ qualys[element.vendor_reference_list] }}',
+        'Exploitability' => '{{ qualys[element.exploitability] }}',
       },
       vuln_evidence: {
         'Location' => "{{ qualys[evidence.cat_protocol] }}/{{ qualys[evidence.cat_port] }}",
@@ -88,6 +89,7 @@ module Dradis::Plugins::Qualys
         'element.pci_flag',
         'element.vendor_reference_list',
         'element.cve_id_list',
+        'element.exploitability',
         'element.bugtraq_id_list',
         'element.diagnosis',
         'element.consequence',

--- a/lib/qualys/element.rb
+++ b/lib/qualys/element.rb
@@ -99,9 +99,7 @@ module Qualys
       method_name = method.to_s
       return @xml.attributes[method_name].value if @xml.attributes.key?(method_name)
 
-      if method == :exploitability
-        return process_exploitability
-      end
+      return exploitability_list if method == :exploitability
 
       tag = @xml.at_xpath("./#{method_name.upcase}")
       if method_name == 'qualys_collection'
@@ -134,7 +132,7 @@ module Qualys
       [:consequence, :diagnosis, :solution]
     end
 
-    def process_exploitability
+    def exploitability_list
       src_nodes = @xml.xpath('./CORRELATION/EXPLOITABILITY/EXPLT_SRC')
       return nil if src_nodes.empty?
 

--- a/lib/qualys/element.rb
+++ b/lib/qualys/element.rb
@@ -55,6 +55,9 @@ module Qualys
         # multiple tags
         :vendor_reference_list, :cve_id_list, :bugtraq_id_list,
 
+        # correlation tags
+        :exploitability,
+
         # category
         :qualys_collection
       ]
@@ -96,6 +99,10 @@ module Qualys
       method_name = method.to_s
       return @xml.attributes[method_name].value if @xml.attributes.key?(method_name)
 
+      if method == :exploitability
+        return process_exploitability
+      end
+
       tag = @xml.at_xpath("./#{method_name.upcase}")
       if method_name == 'qualys_collection'
         @xml.name
@@ -125,6 +132,25 @@ module Qualys
 
     def tags_with_html_content
       [:consequence, :diagnosis, :solution]
+    end
+
+    def process_exploitability
+      src_nodes = @xml.xpath('./CORRELATION/EXPLOITABILITY/EXPLT_SRC')
+      return nil if src_nodes.empty?
+
+      blocks = src_nodes.map do |src|
+        lines = [src.at_xpath('./SRC_NAME')&.text]
+
+        src.xpath('./EXPLT_LIST/EXPLT').each do |explt|
+          lines << explt.at_xpath('./REF')&.text
+          lines << explt.at_xpath('./DESC')&.text
+          lines << explt.at_xpath('./LINK')&.text
+        end
+
+        lines.compact.join("\n")
+      end
+
+      blocks.reject(&:blank?).join("\n\n").presence
     end
   end
 end

--- a/templates/vuln_element.sample
+++ b/templates/vuln_element.sample
@@ -31,6 +31,21 @@
   Using the following SSL configuration in Apache mitigates this vulnerability:<P>
   SSLHonorCipherOrder On<BR>
   SSLCipherSuite RC4-SHA:HIGH:!ADH<BR>]]></SOLUTION>
+    <CORRELATION>
+      <EXPLOITABILITY>
+        <EXPLT_SRC>
+          <SRC_NAME><![CDATA[nvd]]></SRC_NAME>
+          <EXPLT_LIST>
+            <EXPLT>
+              <REF><![CDATA[CVE-2011-3389]]></REF>
+              <DESC><![CDATA[The SSL protocol, as used in certain configurations in Microsoft Windows and Microsoft Internet Explorer, Mozilla Firefox, Google Chrome, Opera, and other products, encrypts data by using CBC mode with chained initialization vectors, which allows man-in-the-middle attackers to obtain plaintext HTTP headers via a blockwise chosen-boundary attack (BCBA) on an HTTPS session, in conjunction with JavaScript code that uses the HTML5 WebSocket API, the Java URLConnection API, or the Silverlight WebClient API, aka a "BEAST" attack.]]></DESC>
+              <LINK><![CDATA[http://www.kb.cert.org/vuls/id/864643]]></LINK>
+            </EXPLT>
+          </EXPLT_LIST>
+        </EXPLT_SRC>
+      </EXPLOITABILITY>
+      <MALWARE />
+    </CORRELATION>
     <RESULT format="table"><![CDATA[Available non CBC cipher	Server&apos;s choice	SSL version
   RC4-SHA	EDH-RSA-DES-CBC3-SHA	SSLv3
   RC4-SHA	EDH-RSA-DES-CBC3-SHA	TLSv1]]></RESULT>


### PR DESCRIPTION
### Summary

This PR allows the CORRELATION > EXPLOITABILITY > EXPLT_SRC tag(s) to be imported into Dradis via the Mappings Manager. 

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [X] Added a CHANGELOG entry
- [X] Added specs (none needed)