### PR TITLE
register upload detectors for auto-detection in the Upload Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v5.1.0 (unreleased)
+  - Qualys: register upload detectors so the Upload Manager can auto-select the correct report type
+
 v5.0.0 (March 2025)
  - Remove HTML tags when importing WAS scans
 

--- a/app/javascript/dradis/plugins/qualys/upload_detectors/asset.js
+++ b/app/javascript/dradis/plugins/qualys/upload_detectors/asset.js
@@ -1,0 +1,6 @@
+import { register } from 'upload_detector_registry'
+
+register({
+  name: 'Dradis::Plugins::Qualys::Asset',
+  match: (sample) => /<ASSET_DATA_REPORT\b/.test(sample)
+})

--- a/app/javascript/dradis/plugins/qualys/upload_detectors/vuln.js
+++ b/app/javascript/dradis/plugins/qualys/upload_detectors/vuln.js
@@ -1,0 +1,8 @@
+import { register } from 'upload_detector_registry'
+
+register({
+  name: 'Dradis::Plugins::Qualys::Vuln',
+  match: (sample) =>
+    /qualysguard|qualys\.com.*scan-\d/.test(sample) ||
+    /<SCAN\s+value="scan\//.test(sample)
+})

--- a/app/javascript/dradis/plugins/qualys/upload_detectors/was.js
+++ b/app/javascript/dradis/plugins/qualys/upload_detectors/was.js
@@ -1,0 +1,6 @@
+import { register } from 'upload_detector_registry'
+
+register({
+  name: 'Dradis::Plugins::Qualys::WAS',
+  match: (sample) => /<WAS_SCAN_REPORT\b/.test(sample)
+})

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,6 +1,2 @@
-pin 'dradis/plugins/qualys/upload_detectors/asset',
-    to: 'dradis/plugins/qualys/upload_detectors/asset.js'
-pin 'dradis/plugins/qualys/upload_detectors/vuln',
-    to: 'dradis/plugins/qualys/upload_detectors/vuln.js'
-pin 'dradis/plugins/qualys/upload_detectors/was',
-    to: 'dradis/plugins/qualys/upload_detectors/was.js'
+pin_all_from Dradis::Plugins::Qualys::Engine.root.join('app/javascript/dradis/plugins/qualys/upload_detectors'),
+             under: 'dradis/plugins/qualys/upload_detectors'

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,6 @@
+pin 'dradis/plugins/qualys/upload_detectors/asset',
+    to: 'dradis/plugins/qualys/upload_detectors/asset.js'
+pin 'dradis/plugins/qualys/upload_detectors/vuln',
+    to: 'dradis/plugins/qualys/upload_detectors/vuln.js'
+pin 'dradis/plugins/qualys/upload_detectors/was',
+    to: 'dradis/plugins/qualys/upload_detectors/was.js'

--- a/lib/dradis/plugins/qualys/engine.rb
+++ b/lib/dradis/plugins/qualys/engine.rb
@@ -6,11 +6,23 @@ module Dradis::Plugins::Qualys
     description 'Processes Qualys output'
     provides :upload
 
+    initializer 'qualys.importmap', before: 'importmap' do |app|
+      app.config.importmap.draw(root.join('config/importmap.rb'))
+    end
+
     # Because this plugin provides two export modules, we have to overwrite
     # the default .uploaders() method.
     #
     # See:
     #  Dradis::Plugins::Upload::Base in dradis-plugins
+    def self.upload_detectors
+      [
+        'dradis/plugins/qualys/upload_detectors/asset',
+        'dradis/plugins/qualys/upload_detectors/vuln',
+        'dradis/plugins/qualys/upload_detectors/was'
+      ]
+    end
+
     def self.uploaders
       [
         Dradis::Plugins::Qualys::Asset,

--- a/lib/dradis/plugins/qualys/engine.rb
+++ b/lib/dradis/plugins/qualys/engine.rb
@@ -6,8 +6,18 @@ module Dradis::Plugins::Qualys
     description 'Processes Qualys output'
     provides :upload
 
+    initializer 'qualys.asset_paths' do |app|
+      app.config.assets.paths << root.join('app/javascript')
+      app.config.assets.precompile += %w[
+        dradis/plugins/qualys/upload_detectors/asset.js
+        dradis/plugins/qualys/upload_detectors/vuln.js
+        dradis/plugins/qualys/upload_detectors/was.js
+      ]
+    end
+
     initializer 'qualys.importmap', before: 'importmap' do |app|
-      app.config.importmap.draw(root.join('config/importmap.rb'))
+      app.config.importmap.paths << root.join('config/importmap.rb')
+      app.config.importmap.cache_sweepers << root.join('app/javascript')
     end
 
     # Because this plugin provides two export modules, we have to overwrite


### PR DESCRIPTION
This is a proof of concept for the multi-file smart upload feature.

### Summary

Registers client-side upload detectors so the Upload Manager can automatically identify the Qualys report type when a file is dropped or selected.

Each detector reads the first 4 KB of the file and matches against a known XML signature:

- **Asset** — `<ASSET_DATA_REPORT>`
- **Vuln** — `<SCAN value="scan/..."` or `qualysguard` in the DOCTYPE
- **WAS** — `<WAS_SCAN_REPORT>`

### Check List

- [x] Added a CHANGELOG entry
- [ ] Added specs